### PR TITLE
fixing partial formats for reuse

### DIFF
--- a/modules/ROOT/pages/administration.adoc
+++ b/modules/ROOT/pages/administration.adoc
@@ -9,7 +9,7 @@ Use these pages to configure administrative settings for your company.
 
 Your company may have been set up during the provisioning process. If so, its name appears at the top of the Name list on the Partner Configuration Page, identified as *Your company*.
 
-include::{partialsdir}/edit-home-partner-settings.adoc[]
+include::partial$edit-home-partner-settings.adoc[]
 
 [start=3]
 

--- a/modules/ROOT/pages/apm-tutorial-td.adoc
+++ b/modules/ROOT/pages/apm-tutorial-td.adoc
@@ -91,11 +91,11 @@ In the following sections, we add identifiers for the supplier. We will add buye
 
 ==== Add Supplier X12-ISA Identifier
 
-include::{partialsdir}/tutorial/supplier/identifier-x12-isa-supplier.adoc[]
+include::partial$tutorial/supplier/identifier-x12-isa-supplier.adoc[]
 
 ==== Add Supplier AS2 Identifier
 
-include::{partialsdir}/tutorial/supplier/identifier-as2-supplier.adoc[]
+include::partial$tutorial/supplier/identifier-as2-supplier.adoc[]
 
 === Upload Certificates
 
@@ -103,7 +103,7 @@ APM provides for the uploading of certificates to verify the identity of a partn
 
 ==== Upload the Supplier Certificate
 
-include::{partialsdir}/tutorial/supplier/certificate-supplier.adoc[]
+include::partial$tutorial/supplier/certificate-supplier.adoc[]
 
 
 == Design a Target Channel
@@ -119,11 +119,11 @@ In this section, you create a template for any transaction in which you receive 
 
 === Start Transaction Designer
 
-include::{partialsdir}/tutorial/supplier/start-td-aaz.adoc[]
+include::partial$tutorial/supplier/start-td-aaz.adoc[]
 
 === Create the Target Channel
 
-include::{partialsdir}/tutorial/supplier/td-target-channel-aaz.adoc[]
+include::partial$tutorial/supplier/td-target-channel-aaz.adoc[]
 
 
 === Create the Source Document Type for the Target Channel
@@ -134,7 +134,7 @@ APM enables you to categorize and configure specific _Document Types_. In this s
 
 ==== To Create the Source Document Type for the Target Channel
 
-include::{partialsdir}/tutorial/supplier/td-target-channel-source-doc-aaz.adoc[]
+include::partial$tutorial/supplier/td-target-channel-source-doc-aaz.adoc[]
 
 
 === Configure Endpoints
@@ -144,7 +144,7 @@ In APM, an endpoint defines the protocol, address, and other details specific to
 
 ==== Configure the Target Endpoint
 
-include::{partialsdir}/tutorial/supplier/td-target-channel-endpoint-aaz.adoc[]
+include::partial$tutorial/supplier/td-target-channel-endpoint-aaz.adoc[]
 
 
 === Save the Transaction
@@ -171,7 +171,7 @@ The <<img-td-target-channel-in-progress-aaz>> appears.
 
 === Create the Buyer Partner
 
-include::{partialsdir}/tutorial/buyer/create-buyer-partner.adoc[]
+include::partial$tutorial/buyer/create-buyer-partner.adoc[]
 
 
 === Add Buyer Identifiers
@@ -249,22 +249,22 @@ The <<img-endpoints>> appears.
 
 === Start Transaction Designer
 
-include::{partialsdir}/tutorial/buyer/start-td-acme.adoc[]
+include::partial$tutorial/buyer/start-td-acme.adoc[]
 
 === Create the Source Channel
 
 
-include::{partialsdir}/tutorial/buyer/td-source-channel-acme.adoc[]
+include::partial$tutorial/buyer/td-source-channel-acme.adoc[]
 
 
 === Create the Source Document
 
-include::{partialsdir}/tutorial/buyer/td-source-channel-source-doc-acme.adoc[]
+include::partial$tutorial/buyer/td-source-channel-source-doc-acme.adoc[]
 
 
 === Create the Buyer Receive Endpoint
 
-include::{partialsdir}/tutorial/buyer/td-source-channel-endpoint-acme.adoc[]
+include::partial$tutorial/buyer/td-source-channel-endpoint-acme.adoc[]
 
 Note that, on the <<img-td-possible-endpoints-no-property-acme>>, the warning *1 property cannot be found in the document type* appears.
 

--- a/modules/ROOT/pages/certificate.adoc
+++ b/modules/ROOT/pages/certificate.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 The <<img-certificate>> enables you to upload an AS2 or RNIF certificate for the partner you selected on the xref:partner-configuration.adoc#img-partner-configuration[Partner Configuration Page].
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 
 [start=3]
 

--- a/modules/ROOT/pages/channels.adoc
+++ b/modules/ROOT/pages/channels.adoc
@@ -10,7 +10,7 @@ Document:: As created in xref:document-types.adoc[Document Types]
 Document Map:: As created in xref:maps.adoc[Maps]
 Endpoint:: As created in xref:endpoints.adoc[Endpoints]
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 [start=3]
 
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *Channels*.

--- a/modules/ROOT/pages/csv-settings.adoc
+++ b/modules/ROOT/pages/csv-settings.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 
 [start=3]
 

--- a/modules/ROOT/pages/document-types.adoc
+++ b/modules/ROOT/pages/document-types.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 Configuring a _document type_ for a partner means configuring settings specific to that document type.
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 [start=3]
 
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *Document Types*.

--- a/modules/ROOT/pages/edifact-settings.adoc
+++ b/modules/ROOT/pages/edifact-settings.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 EDIFACT (Electronic Data Interchange For Administration, Commerce and Transport) provides a set of standard messages which allow multi-country and multi-industry business document exchanges. EDIFACT is widely used across Europe.
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 
 [start=3]
 

--- a/modules/ROOT/pages/endpoints.adoc
+++ b/modules/ROOT/pages/endpoints.adoc
@@ -6,7 +6,7 @@ endif::[]
 An _endpoint_ is the entry point to a service, a process, or a queue or topic destination in service-oriented architecture. In APM, an endpoint defines the protocol, address, and other details specific to an exchange of messages between partners.
 
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 
 [start=3]
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *Endpoints*.
@@ -213,18 +213,18 @@ Valid values::
 |===
 
 
-include::{partialsdir}/endpoint-as2-send.adoc[]
-include::{partialsdir}/endpoint-as2-receive.adoc[]
-include::{partialsdir}/endpoint-ftp-send.adoc[]
-include::{partialsdir}/endpoint-ftps-send.adoc[]
-include::{partialsdir}/endpoint-ftps-receive.adoc[]
-include::{partialsdir}/endpoint-sftp-send.adoc[]
-include::{partialsdir}/endpoint-sftp-receive.adoc[]
-include::{partialsdir}/endpoint-http-send.adoc[]
-include::{partialsdir}/endpoint-http-receive.adoc[]
-include::{partialsdir}/endpoint-jms-send.adoc[]
-include::{partialsdir}/endpoint-jms-receive.adoc[]
-include::{partialsdir}/endpoint-smtp-send.adoc[]
-include::{partialsdir}/endpoint-pop3-receive.adoc[]
-include::{partialsdir}/endpoint-imap-receive.adoc[]
-include::{partialsdir}/endpoint-rnif.adoc[]
+include::partial$endpoint-as2-send.adoc[]
+include::partial$endpoint-as2-receive.adoc[]
+include::partial$endpoint-ftp-send.adoc[]
+include::partial$endpoint-ftps-send.adoc[]
+include::partial$endpoint-ftps-receive.adoc[]
+include::partial$endpoint-sftp-send.adoc[]
+include::partial$endpoint-sftp-receive.adoc[]
+include::partial$endpoint-http-send.adoc[]
+include::partial$endpoint-http-receive.adoc[]
+include::partial$endpoint-jms-send.adoc[]
+include::partial$endpoint-jms-receive.adoc[]
+include::partial$endpoint-smtp-send.adoc[]
+include::partial$endpoint-pop3-receive.adoc[]
+include::partial$endpoint-imap-receive.adoc[]
+include::partial$endpoint-rnif.adoc[]

--- a/modules/ROOT/pages/environments.adoc
+++ b/modules/ROOT/pages/environments.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-include::{partialsdir}/edit-home-partner-settings.adoc[]
+include::partial$edit-home-partner-settings.adoc[]
 [start=3]
 
 . On the Administration Page, in the left hand navigation pane, click *Environments*.

--- a/modules/ROOT/pages/error-codes.adoc
+++ b/modules/ROOT/pages/error-codes.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-include::{partialsdir}/edit-home-partner-settings.adoc[]
+include::partial$edit-home-partner-settings.adoc[]
 
 [start=3]
 

--- a/modules/ROOT/pages/identifiers.adoc
+++ b/modules/ROOT/pages/identifiers.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 
 [start=3]
 

--- a/modules/ROOT/pages/lookup-tables.adoc
+++ b/modules/ROOT/pages/lookup-tables.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 Anypoint Partner Manager (APM) enables you to create, populate and edit a _lookup table_.  A lookup table is a table that facilitates transaction processing by associating values. For example, this page shows how to create a lookup table that associates internal partner product codes with customer product codes.
 
-include::{partialsdir}/edit-home-partner-settings.adoc[]
+include::partial$edit-home-partner-settings.adoc[]
 
 . If you want to create a lookup table or edit the name, fields or keys for an existing table, go to <<Administer a Lookup Table>>.
 The fields you add will become the columns of the table.

--- a/modules/ROOT/pages/maps.adoc
+++ b/modules/ROOT/pages/maps.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Configuring a _map_ for a partner enables you to specify:
+Configuring a map for a partner enables you to specify:
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 [start=3]
 
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *Maps*.

--- a/modules/ROOT/pages/maps.adoc
+++ b/modules/ROOT/pages/maps.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Configuring a map for a partner enables you to specify:
+Configuring a _map_ for a partner enables you to specify:
 
 include::partial$edit-settings.adoc[]
 [start=3]

--- a/modules/ROOT/pages/on-hold-inactive.adoc
+++ b/modules/ROOT/pages/on-hold-inactive.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 You can configure windows (periods of time) during which partners or transactions are on-hold or inactive.
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 [start=3]
 
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *On-Hold/Inactive*.

--- a/modules/ROOT/pages/partner-conversations.adoc
+++ b/modules/ROOT/pages/partner-conversations.adoc
@@ -7,7 +7,7 @@ When you create a  _Partner Conversation_, you establish a sequence of events be
 
 This page provides instructing for creating and editing Partner Conversations. For information about tracking Conversations, see  xref:transaction-monitoring.adoc[Transaction Monitoring].
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 
 [start=3]
 

--- a/modules/ROOT/pages/rosettanet-agreements.adoc
+++ b/modules/ROOT/pages/rosettanet-agreements.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Configuring a _agreement type_ for a partner means specifying a *Name* and
+Configuring an _agreement type_ for a partner means specifying a *Name* and
 
 include::partial$edit-settings.adoc[]
 [start=3]

--- a/modules/ROOT/pages/rosettanet-agreements.adoc
+++ b/modules/ROOT/pages/rosettanet-agreements.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 Configuring a _agreement type_ for a partner means specifying a *Name* and
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 [start=3]
 
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *RosettaNet Agreements*.

--- a/modules/ROOT/pages/rosettanet-pips.adoc
+++ b/modules/ROOT/pages/rosettanet-pips.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Configuring a _PIP type_ for a partner means specifying a *Name* and *Process Code*.
+Configuring a PIP type for a partner means specifying a *Name* and *Process Code*.
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 [start=3]
 
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *RosettaNet PIPs*.

--- a/modules/ROOT/pages/rosettanet-pips.adoc
+++ b/modules/ROOT/pages/rosettanet-pips.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Configuring a PIP type for a partner means specifying a *Name* and *Process Code*.
+Configuring a _PIP type_ for a partner means specifying a *Name* and *Process Code*.
 
 include::partial$edit-settings.adoc[]
 [start=3]

--- a/modules/ROOT/pages/routes.adoc
+++ b/modules/ROOT/pages/routes.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 Configuring a _route_ for a partner enables you to specify:
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 [start=3]
 
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *Routes*.

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-include::{partialsdir}/edit-home-partner-settings.adoc[]
+include::partial$edit-home-partner-settings.adoc[]
 
 [start=3]
 

--- a/modules/ROOT/pages/transaction-designer.adoc
+++ b/modules/ROOT/pages/transaction-designer.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-_Transaction Designer_ is an APM feature that enables you to design the _elements_ of a transaction. Transaction elements include:
+Transaction Designer is an APM feature that enables you to design the elements of a transaction. Transaction elements include:
 
 * Document Types
 * Endpoints
@@ -14,7 +14,7 @@ _Transaction Designer_ is an APM feature that enables you to design the _element
 Transaction Designer enables you to configure these elements from a central page that displays the elements along with their completion status, and what steps may remain in order to complete them. To see how to use this feature to create a transaction that receives a Purchase Order, see  xref:apm-tutorial-td.adoc[Anypoint Partner Manager Tutorial: Designing a Transaction].
 
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 [start=3]
 
 . In the *CONFIGURATION* section of the left-hand navigation pane on the xref:partner-configuration.adoc#img-company-information[Company Information Page], click *Transaction Designer*.

--- a/modules/ROOT/pages/transaction-designer.adoc
+++ b/modules/ROOT/pages/transaction-designer.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Transaction Designer is an APM feature that enables you to design the elements of a transaction. Transaction elements include:
+_Transaction Designer_ is an APM feature that enables you to design the _elements_ of a transaction. Transaction elements include:
 
 * Document Types
 * Endpoints

--- a/modules/ROOT/pages/working-with-environments.adoc
+++ b/modules/ROOT/pages/working-with-environments.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-NOTE: Current Anypoint Partner Manager solutions are supported in accordance with the https://www.mulesoft.com/legal/support-maintenance-terms[Product Support and Maintenance Terms] but are not available for new customers or upgrades. Contact your MuleSoft representative for more information on MuleSoft's B2B solutions.
+NOTE: Current Anypoint Partner Manager solutions will continue to be supported in accordance with the https://www.mulesoft.com/legal/support-maintenance-terms[Product Support and Maintenance Terms] but will not be available for new customers or upgrades. Contact your MuleSoft representative for more information on MuleSoft's B2B solutions.
 
 include::partial$promotion-scenarios.adoc[leveloffset=+1]
 

--- a/modules/ROOT/pages/working-with-environments.adoc
+++ b/modules/ROOT/pages/working-with-environments.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-NOTE: Current Anypoint Partner Manager solutions will continue to be supported in accordance with the https://www.mulesoft.com/legal/support-maintenance-terms[Product Support and Maintenance Terms] but will not be available for new customers or upgrades. Contact your MuleSoft representative for more information on MuleSoft's B2B solutions.
+NOTE: Current Anypoint Partner Manager solutions are supported in accordance with the https://www.mulesoft.com/legal/support-maintenance-terms[Product Support and Maintenance Terms] but are not available for new customers or upgrades. Contact your MuleSoft representative for more information on MuleSoft's B2B solutions.
 
-include::{partialsdir}/promotion-scenarios.adoc[leveloffset=+1]
+include::partial$promotion-scenarios.adoc[leveloffset=+1]
 
 
 == Rough Draft Graphic For Certs Promo

--- a/modules/ROOT/pages/x12-settings.adoc
+++ b/modules/ROOT/pages/x12-settings.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 X12 standards define the structure, format, and content of business transactions conducted through Electronic Data Interchange (EDI) and are used in conjunction with AS2 or FTPS as transport for these documents.
 
-include::{partialsdir}/edit-settings.adoc[]
+include::partial$edit-settings.adoc[]
 
 [start=3]
 


### PR DESCRIPTION
Just changing the syntax of some reuse "include" links so they are consistent with the current recommended syntax. I have ignored all style issues as this is just an infrastructure-related change.
Ran a local build using fullsite.yml, and the expected content showed up in every file.
Ran a local link checker using fullsite.yml, and no errors returned.