### PR TITLE
W-11585544: Update Studio version

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -48,9 +48,9 @@ This page assumes that you are familiar with:
 * Mule
 * xref:3.8@mule-runtime::anypoint-connectors.adoc[Anypoint Connectors]
 * The Anypoint Studio interface (for information about the interface, see
-xref:6@studio::index.adoc[Anypoint Studio Essentials]).
+xref:6.x@studio::index.adoc[Anypoint Studio Essentials]).
 To increase your familiarity with Studio, consider completing one or more
-xref:6@studio::basic-studio-tutorial.adoc[Anypoint Studio Tutorials].
+xref:6.x@studio::basic-studio-tutorial.adoc[Anypoint Studio Tutorials].
 * xref:3.8@mule-runtime::mule-concepts.adoc#flows[Mule Flows]
 * xref:3.8@mule-runtime::global-elements.adoc[Mule Global Elements]
 


### PR DESCRIPTION
This PR fixes the broken links to older versions of Studio due to the updated 'version' field.

See 

- [W-11585544](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000013ulwzYAA/view) 
- https://github.com/mulesoft/docs-studio/pull/350
- https://github.com/mulesoft/docs-studio/pull/351  
 
for more details.